### PR TITLE
feat: add undo history and whitespace trimming

### DIFF
--- a/after/ftplugin/lua.lua
+++ b/after/ftplugin/lua.lua
@@ -1,0 +1,3 @@
+vim.opt_local.tabstop = 4
+vim.opt_local.shiftwidth = 2
+vim.opt_local.expandtab = false -- true = space, false = tabs

--- a/init.lua
+++ b/init.lua
@@ -4,42 +4,48 @@
 vim.o.splitright = true
 vim.o.splitbelow = true
 
+-- undo settings
+vim.o.undofile = true
+vim.o.undodir = vim.fn.stdpath("data") .. "/undo"
+
+-- recursive search for :find
+vim.o.path = vim.o.path .. "**"
+
 -- Bootstrap lazy.nvim
-local lazypath = vim.fn.stdpath 'data' .. '/lazy/lazy.nvim'
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
 if not (vim.uv or vim.loop).fs_stat(lazypath) then
-  local lazyrepo = 'https://github.com/folke/lazy.nvim.git'
-  local out = vim.fn.system { 'git', 'clone', '--filter=blob:none', '--branch=stable', lazyrepo, lazypath }
-  if vim.v.shell_error ~= 0 then
-    vim.api.nvim_echo({
-      { 'Failed to clone lazy.nvim:\n', 'ErrorMsg' },
-      { out, 'WarningMsg' },
-      { '\nPress any key to exit...' },
-    }, true, {})
-    vim.fn.getchar()
-    os.exit(1)
-  end
+	local lazyrepo = "https://github.com/folke/lazy.nvim.git"
+	local out = vim.fn.system({ "git", "clone", "--filter=blob:none", "--branch=stable", lazyrepo, lazypath })
+	if vim.v.shell_error ~= 0 then
+		vim.api.nvim_echo({
+			{ "Failed to clone lazy.nvim:\n", "ErrorMsg" },
+			{ out, "WarningMsg" },
+			{ "\nPress any key to exit..." },
+		}, true, {})
+		vim.fn.getchar()
+		os.exit(1)
+	end
 end
 vim.opt.rtp:prepend(lazypath)
 
 -- Make sure to setup `mapleader` and `maplocalleader` before
 -- loading lazy.nvim so that mappings are correct.
 -- This is also a good place to setup other settings (vim.opt)
-vim.g.mapleader = ' '
-vim.g.maplocalleader = '\\'
+vim.g.mapleader = " "
+vim.g.maplocalleader = "\\"
 
 -- Setup lazy.nvim
-require('lazy').setup {
-  spec = {
-    -- import your plugins
-    { import = 'plugins' },
-  },
-  -- Configure any other settings here. See the documentation for more details.
-  -- colorscheme that will be used when installing plugins.
-  install = { colorscheme = { 'habamax' } },
-  -- automatically check for plugin updates
-  checker = { enabled = true },
-}
+require("lazy").setup({
+	spec = {
+		-- import your plugins
+		{ import = "plugins" },
+	},
+	-- Configure any other settings here. See the documentation for more details.
+	-- colorscheme that will be used when installing plugins.
+	install = { colorscheme = { "habamax" } },
+	-- automatically check for plugin updates
+	checker = { enabled = true },
+})
 
 -- Keymappings are defined in lua/keymappings.lua
-require('keymappings')
-
+require("keymappings")

--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -1,9 +1,10 @@
 {
-  "CopilotChat.nvim": { "branch": "main", "commit": "78595bb6153dd835c1bfd797de6ab073c093d4ad" },
+  "CopilotChat.nvim": { "branch": "main", "commit": "1f91783fdf7dcea25c04dffc8e856ccb7a2db13f" },
   "copilot.vim": { "branch": "release", "commit": "5015939f131627a6a332c9e3ecad9a7cb4c2e549" },
   "lazy.nvim": { "branch": "main", "commit": "6c3bda4aca61a13a9c63f1c1d1b16b9d3be90d7a" },
   "nvim-web-devicons": { "branch": "master", "commit": "ab4cfee554e501f497bce0856788d43cf2eb93d7" },
   "oil.nvim": { "branch": "master", "commit": "548587d68b55e632d8a69c92cefd981f360634fa" },
   "plenary.nvim": { "branch": "master", "commit": "857c5ac632080dba10aae49dba902ce3abf91b35" },
-  "substitute.nvim": { "branch": "main", "commit": "97f49d16f8eea7967d41db4f657dd63af53eeba1" }
+  "substitute.nvim": { "branch": "main", "commit": "97f49d16f8eea7967d41db4f657dd63af53eeba1" },
+  "whitespace.nvim": { "branch": "master", "commit": "f7d14be0f23a9c1e8021aca70d280aea26649b68" }
 }

--- a/lua/keymappings.lua
+++ b/lua/keymappings.lua
@@ -1,1 +1,2 @@
 vim.keymap.set('n', '<leader>W', ":lua require('whitespace-nvim').trim()<CR>", { desc = 'Trim whitespaces' })
+vim.keymap.set('n', '<leader><space>', "<C-^>", { desc = 'Edit alternate file' })


### PR DESCRIPTION
- Added undo settings in `init.lua` to enable persistent undo and set the undo directory.
- Configured recursive search for `:find` command in `init.lua`.
- Updated lazy.nvim bootstrap code in `init.lua` for consistency.
- Added new file `after/ftplugin/lua.lua` to set local options for Lua files.
- Updated `lazy-lock.json` with new plugin versions.
- Added keymapping in `lua/keymappings.lua` to trim whitespaces and edit alternate file.