### PR TITLE
feat(telescope): add telescope plugin and key mappings

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -6,5 +6,6 @@
   "oil.nvim": { "branch": "master", "commit": "548587d68b55e632d8a69c92cefd981f360634fa" },
   "plenary.nvim": { "branch": "master", "commit": "857c5ac632080dba10aae49dba902ce3abf91b35" },
   "substitute.nvim": { "branch": "main", "commit": "97f49d16f8eea7967d41db4f657dd63af53eeba1" },
+  "telescope.nvim": { "branch": "master", "commit": "a0bbec21143c7bc5f8bb02e0005fa0b982edc026" },
   "whitespace.nvim": { "branch": "master", "commit": "f7d14be0f23a9c1e8021aca70d280aea26649b68" }
 }

--- a/lua/keymappings.lua
+++ b/lua/keymappings.lua
@@ -1,2 +1,8 @@
-vim.keymap.set('n', '<leader>W', ":lua require('whitespace-nvim').trim()<CR>", { desc = 'Trim whitespaces' })
-vim.keymap.set('n', '<leader><space>', "<C-^>", { desc = 'Edit alternate file' })
+vim.keymap.set("n", "<leader>W", ":lua require('whitespace-nvim').trim()<CR>", { desc = "Trim whitespaces" })
+vim.keymap.set("n", "<leader><space>", "<C-^>", { desc = "Edit alternate file" })
+
+local builtin = require("telescope.builtin")
+vim.keymap.set("n", "<leader>sf", builtin.find_files, { desc = "Telescope find files" })
+vim.keymap.set("n", "<leader>sg", builtin.live_grep, { desc = "Telescope live grep" })
+vim.keymap.set("n", "<leader>sb", builtin.buffers, { desc = "Telescope buffers" })
+vim.keymap.set("n", "<leader>sh", builtin.help_tags, { desc = "Telescope help tags" })

--- a/lua/plugins/telescope.lua
+++ b/lua/plugins/telescope.lua
@@ -1,0 +1,5 @@
+return {
+	"nvim-telescope/telescope.nvim",
+	tag = "0.1.8",
+	dependencies = { "nvim-lua/plenary.nvim" },
+}


### PR DESCRIPTION
- Added `telescope.nvim` plugin to the project.
- Updated `lazy-lock.json` to include the new plugin.
- Modified `lua/keymappings.lua` to add key mappings for Telescope:
  - `<leader>sf` to find files
  - `<leader>sg` for live grep
  - `<leader>sb` to list buffers
  - `<leader>sh` to show help tags
- Created `lua/plugins/telescope.lua` to configure the plugin with dependencies.